### PR TITLE
name can be updated without forcing environment to be recreated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 !/examples/main.tf
 /examples/*
 bin
+.idea

--- a/ccloud/resource_environment.go
+++ b/ccloud/resource_environment.go
@@ -18,7 +18,7 @@ func environmentResource() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
+				ForceNew:    false,
 				Description: "The name of the environment",
 			},
 		},


### PR DESCRIPTION
fixes https://github.com/Mongey/terraform-provider-confluent-cloud/issues/9

Field "name" can be updated without forcing the environment to be recreated.