### PR TITLE
Update binary name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+project_name: terraform-provider-confluentcloud
 builds:
   - binary: "{{ .ProjectName }}_v{{ .Version }}"
     env:


### PR DESCRIPTION
Terraform expects providers to be a single word. `confluentcloud` rather than `confluent-cloud` Fixes #14 